### PR TITLE
LRDOCS-5593 Wordsmithed. Bug with asset publisher, and related assets don't work

### DIFF
--- a/develop/tutorials/articles/04-developing-a-web-application/09-assets/03-adding-asset-features-to-your-user-interface/00-adding-asset-features-to-your-user-interface-intro.markdown
+++ b/develop/tutorials/articles/04-developing-a-web-application/09-assets/03-adding-asset-features-to-your-user-interface/00-adding-asset-features-to-your-user-interface-intro.markdown
@@ -16,7 +16,7 @@ imports to the `guestbook-web` module project's `init.jsp` file:
 
 
     <%@ taglib uri="http://liferay.com/tld/asset" prefix="liferay-asset" %>
-    <%@ taglib prefix="liferay-comment" uri="http://liferay.com/tld/comment" %>
+    <%@ taglib uri="http://liferay.com/tld/comment" prefix="liferay-comment" %>
 
     <%@ page import="java.util.Map" %> 
     <%@ page import="java.util.HashMap" %>

--- a/develop/tutorials/articles/04-developing-a-web-application/09-assets/03-adding-asset-features-to-your-user-interface/04-enabling-comments-and-ratings-for-entries.markdown
+++ b/develop/tutorials/articles/04-developing-a-web-application/09-assets/03-adding-asset-features-to-your-user-interface/04-enabling-comments-and-ratings-for-entries.markdown
@@ -110,7 +110,7 @@ ratings on guestbook entries:
           classPK="<%=entry.getEntryId()%>" type="stars" />
 
         <br />
-    
+
 9.  Next you need to add a scriptlet to retrieve the comments discussion object:
 
         <% Discussion discussion = 
@@ -125,8 +125,10 @@ ratings on guestbook entries:
           <h2>
             <strong><liferay-ui:message arguments="<%= discussion.getDiscussionCommentsCount() %>" key='<%= (discussion.getDiscussionCommentsCount() == 1) ? "x-comment" : "x-comments" %>' /></strong>
 
-11. And then create the `liferay-comment:discussion` tag which handles the 
-    creation of the comments form, *Reply* button, and retrieving the discussion content. It also handles the form action of posting the comment without requiring you to create a portlet action URL.
+11. Create the `liferay-comment:discussion` tag, which creates the comments
+    form, *Reply* button, and retrieves the discussion content. It also
+    handles the form action of posting the comment without requiring
+    you to create a portlet action URL.
           
           <liferay-comment:discussion
             className="<%= Entry.class.getName() %>"


### PR DESCRIPTION
I'm getting the 'something is trying to circumvent permissions' in Asset Publisher, and I can relate assets to Guestbook entries, but then I can't see those relationships in the view_entry.jsp.